### PR TITLE
"/" is replaced with "and than"

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ to review the code for your analysis**.
 For the plotting aspects of this assignment, feel free to use any
 plotting system in R (i.e., base, lattice, ggplot2)
 
-Fork/clone the [GitHub repository created for this
+Fork and than clone the [GitHub repository created for this
 assignment](http://github.com/rdpeng/RepData_PeerAssessment1). You
 will submit this assignment by pushing your completed files into your
 forked repository on GitHub. The assignment submission will consist of


### PR DESCRIPTION
In some countries the "/" has meaning of "OR" so it is a little bit confusing to see "OR" here because it seems that it is useless to make just clone without the fork.
In case the change has sense and this md file is not used in description of "Peer Assessment 1" than, please, consider making the same change in the "Peer Assessment 1" description.
